### PR TITLE
experiment with HTTP status of index

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ integrity of your system (not grow exponentially in size).
     </Location>
     <LocationMatch /<client>/(index/login/redirect)$ >
 	    SetEnv CLIENT_PATH <client>
-        AuthType None
+	    AuthType None
 	    <RequireAll>
 		    Require all granted
 	    </RequireAll>

--- a/README.md
+++ b/README.md
@@ -22,12 +22,6 @@ integrity of your system (not grow exponentially in size).
     Alias /<client>/index /usr/local/src/mindie-client/indieauth-client-php/index.php
     Alias /<client>/login /usr/local/src/mindie-client/indieauth-client-php/login.php
     Alias /<client>/redirect /usr/local/src/mindie-client/indieauth-client-php/redirect.php
-    <LocationMatch /<client>/(index/login/redirect)$ >
-	    SetEnv CLIENT_PATH <client>
-	    <RequireAll>
-		    Require all granted
-	    </RequireAll>
-    </LocationMatch>
     <Directory /usr/local/src/mindie-client/indieauth-client-php/>
 	    AllowOverride AuthConfig
     </Directory>
@@ -44,6 +38,13 @@ integrity of your system (not grow exponentially in size).
 		    Require valid-user
 	    </RequireAll>
     </Location>
+    <LocationMatch /<client>/(index/login/redirect)$ >
+	    SetEnv CLIENT_PATH <client>
+        AuthType None
+	    <RequireAll>
+		    Require all granted
+	    </RequireAll>
+    </LocationMatch>
     ```
 
 This will setup the following endpoints on your Apache server:

--- a/indieauth-client-php.conf.example
+++ b/indieauth-client-php.conf.example
@@ -2,16 +2,12 @@
 Alias /oauth/index /usr/local/src/mindie-client/indieauth-client-php/index.php
 Alias /oauth/login /usr/local/src/mindie-client/indieauth-client-php/login.php
 Alias /oauth/redirect /usr/local/src/mindie-client/indieauth-client-php/redirect.php
-<LocationMatch /oauth/(index/login/redirect)$ >
-	SetEnv CLIENT_PATH oauth
-	<RequireAll>
-		Require all granted
-	</RequireAll>
-</LocationMatch>
 <Directory /usr/local/src/mindie-client/indieauth-client-php/>
 	AllowOverride AuthConfig
 </Directory>
-<Location /oauth/content>
+<Location /oauth/content/>
+# Alternatively
+# <Location /oauth/>
 	SetEnv CLIENT_PATH oauth
 	AuthType oauth2
 	AuthName "Hello OAuth"
@@ -22,5 +18,12 @@ Alias /oauth/redirect /usr/local/src/mindie-client/indieauth-client-php/redirect
 		Require valid-user
 	</RequireAll>
 </Location>
+<LocationMatch /oauth/(index/login/redirect)$ >
+	SetEnv CLIENT_PATH oauth
+	AuthType None
+	<RequireAll>
+		Require all granted
+	</RequireAll>
+</LocationMatch>
 
 # vim: syntax=apache ts=4 sw=4 sts=4 sr noet


### PR DESCRIPTION
interestingly enough, without `AuthType None` it gives 401 but still serves the content. The redirect will also serve the content *here*, but on another box (may have other differences) it refuses to redirect citing a 401.

Adding `AuthType None` AND moving it below will give 200. Alternatively, the app path can be rooted side-by-side (as /oauth/content and /oauth/index instead of /oauth and /oauth/index).